### PR TITLE
remove unrelated package dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Babel==2.5.3
 docopt==0.6.2
 ipywidgets==7.4.2
 joblib==0.11


### PR DESCRIPTION
Dependabot alerts about Babel, but we do not use Babel but use nibabel.